### PR TITLE
Fixes textIndexer for not breaking on empty fields 

### DIFF
--- a/docs/CREDITS.txt
+++ b/docs/CREDITS.txt
@@ -11,6 +11,7 @@ following people:
 - Silvestre Huens
 - Gonzalo Almeida
 - Franco Pellegrini
+- João S. O. Bueno
 
 Development sponsored by Open Multimedia.
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -30,7 +30,7 @@ Because you have to know where your towel is.
 
 - Adds support to new-style Collections. [davilima6]
 
-
+- Fixes Unicode handling for indexing [hvelarde] [jsbueno]
 1.0a3 (2012-07-06)
 ^^^^^^^^^^^^^^^^^^
 

--- a/src/collective/nitf/content.py
+++ b/src/collective/nitf/content.py
@@ -162,7 +162,8 @@ def textIndexer(obj):
     # XXX: this can be avoided giving 'text' a default value above
     text = transformer(obj.text, 'text/plain') if obj.text else ""
 
-    searchable_text = [safe_unicode(entry) for entry in (
+    searchable_text = [safe_unicode(entry) if entry is not None else u""
+         for entry in (
         obj.id,
         obj.Title(),
         obj.subtitle,


### PR DESCRIPTION
The latest change by Hvelarde would break when any field was None - even a not required field.

This one line change fixes that replacing the `None`value with u""  before joining the field contents to compose the index. 
