### PR TITLE
Handle corner case when upgrade step for 1008 found a collection with no query defined

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,8 @@ There's a frood who really knows where his towel is
 1.0b9 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Handle corner case when upgrade step for 1008 found a collection with no query defined.
+  [hvelarde]
 
 
 1.0b8 (2015-10-16)

--- a/src/collective/nitf/upgrades/v1008/__init__.py
+++ b/src/collective/nitf/upgrades/v1008/__init__.py
@@ -24,6 +24,9 @@ def fix_collections(context):
         except AttributeError:
             query = obj.getQuery()  # Dexterity
 
+        if query is None:
+            continue  # collection has no query defined
+
         fixed_query = []
         for item in query:
             fixed_item = dict(item)


### PR DESCRIPTION
closes #186 