### PR TITLE
Handle corner case when upgrade step for 1008 found a collection with no query defined

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 2.0b5 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Handle corner case when upgrade step for 1008 found a collection with no query defined.
+  [hvelarde]
+
 - Simplify slideshow template to avoid depending on context id;
   this solves an issue when id ends with ".html".
   [rodfersou]

--- a/src/collective/nitf/upgrades/v1008/__init__.py
+++ b/src/collective/nitf/upgrades/v1008/__init__.py
@@ -24,6 +24,9 @@ def fix_collections(context):
         except AttributeError:
             query = obj.getQuery()  # Dexterity
 
+        if query is None:
+            continue  # collection has no query defined
+
         fixed_query = []
         for item in query:
             fixed_item = dict(item)


### PR DESCRIPTION
refs. #186 