### PR TITLE
Don't render tile for anon if unpublished nitf.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ There's a frood who really knows where his towel is.
 2.1b2 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Don't render tile for anonymous users if related nitf content is unpublished.
+  (closes `#185`_).
+  [idgserpro]
+
 - Fix upgrade process between versions 1.0 and 2.0;
   check documentation on migration from 1.x to 2.x (closes `#198`_).
   [rodfersou, hvelarde]
@@ -196,4 +200,5 @@ There's a frood who really knows where his towel is.
 .. _`#169`: https://github.com/collective/collective.nitf/issues/169
 .. _`#175`: https://github.com/collective/collective.nitf/issues/175
 .. _`#178`: https://github.com/collective/collective.nitf/issues/178
+.. _`#185`: https://github.com/collective/collective.nitf/issues/185
 .. _`#198`: https://github.com/collective/collective.nitf/issues/198

--- a/src/collective/nitf/config.py
+++ b/src/collective/nitf/config.py
@@ -201,3 +201,5 @@ JS_RESOURCES = (
     '++resource++collective.js.cycle2/jquery.cycle2.carousel.min.js',
     '++resource++collective.js.cycle2/jquery.cycle2.swipe.min.js',
 )
+
+NOT_RENDERED_ANONYMOUS_TILE_TOKEN = '<span id="tile-content-not-available"></span>'

--- a/src/collective/nitf/tiles/nitf.py
+++ b/src/collective/nitf/tiles/nitf.py
@@ -3,7 +3,9 @@ from collective.cover.tiles.basic import BasicTile
 from collective.cover.tiles.basic import IBasicTile
 from collective.cover.tiles.configuration_view import IDefaultConfigureForm
 from collective.nitf import _
+from collective.nitf.config import NOT_RENDERED_ANONYMOUS_TILE_TOKEN
 from collective.nitf.interfaces import INITF
+from plone import api
 from plone.autoform import directives as form
 from plone.tiles.interfaces import ITileDataManager
 from plone.uuid.interfaces import IUUID
@@ -46,6 +48,33 @@ class NITFTile(BasicTile):
     is_droppable = True
 
     short_name = _(u'msg_short_name_nitf', u'News Article')
+
+    def __call__(self, *args, **kwargs):
+        """
+        This method was inspired by
+
+            https://github.com/plone/plone.tiles/blob/5f13cc63efc3c0ee429ff103685b19161333afd7/plone/tiles/esi.py#L59
+
+        Based on ConditionalESIRendering, if there's no index, 'render' is
+        called instead. We used the same idea but for a different purpose: if
+        the object related to the tile isn't available (happens when an
+        anonymous user tries to view an unpublished item in a tile), we show
+        a message saying that there's a privilege problem. If the tile is
+        available, __call__ is normally called.
+        """
+        if api.user.is_anonymous() and self.brain is None and not self.is_compose_mode():
+            # XXX: We can't return an empty string or
+            # 'Tile content replaced during the blocks transform.'
+            # will be shown. Usually, when an empty string is rendered from a
+            # tile means an error (like Internal Server Error) and render_section
+            # https://github.com/collective/collective.cover/blob/445db248ac5e10cb54d3bcc70fb3a8b9381d4730/src/collective/cover/browser/layout.py#L131
+            # renders this default message. To avoid messing up with the
+            # expectation of 'Tile content replaced during the blocks transform.'
+            # being usually shown when there's a problem, we'll return a
+            # harmless span.
+            return NOT_RENDERED_ANONYMOUS_TILE_TOKEN
+        else:
+            return super(NITFTile, self).__call__(*args, **kwargs)
 
     def accepted_ct(self):
         """Return a list of content types accepted by the tile."""


### PR DESCRIPTION
This fixes #185 

Showing a default Plone message of "Insufficient Privileges" when an Anonymous user renders a tile that have an unpublished nitf associated to the tile.