### PR TITLE
Remove relatable_content_types record 1.x -> 2.x.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,7 @@ There's a frood who really knows where his towel is.
 2.1b3 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Add removal of relatable_content_types registry to upgradeStep between 1.x
-  and 2.x upgrade (closes `#208`_).
+- Remove ``relatable_content_types`` registry record when upgrading to 2.x (closes `#208`_).
   [idgserpro]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ There's a frood who really knows where his towel is.
 2.1b3 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Add removal of relatable_content_types registry to upgradeStep between 1.x
+  and 2.x upgrade (closes `#208`_).
+  [idgserpro]
 
 
 2.1b2 (2017-06-12)
@@ -205,3 +207,4 @@ There's a frood who really knows where his towel is.
 .. _`#175`: https://github.com/collective/collective.nitf/issues/175
 .. _`#178`: https://github.com/collective/collective.nitf/issues/178
 .. _`#198`: https://github.com/collective/collective.nitf/issues/198
+.. _`#208`: https://github.com/collective/collective.nitf/issues/208

--- a/src/collective/nitf/upgrades/v2000/profile/registry.xml
+++ b/src/collective/nitf/upgrades/v2000/profile/registry.xml
@@ -6,4 +6,5 @@
   <record name="collective.nitf.controlpanel.INITFCharCountSettings.show_title_counter" delete="true" />
   <record name="collective.nitf.controlpanel.INITFCharCountSettings.title_max_chars" delete="true" />
   <record name="collective.nitf.controlpanel.INITFCharCountSettings.title_optimal_chars" delete="true" />
+  <record name="collective.nitf.controlpanel.INITFSettings.relatable_content_types" delete="true" />
 </registry>


### PR DESCRIPTION
A test is not possible since relatable_content_types was in INITFSettings in
1.x but removed in 2.x. We can't add to registry without error.

Closes https://github.com/collective/collective.nitf/issues/208