### PR TITLE
Fix error when creating Plone Site, when collective.nitf is available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .project
 .pydevproject
 .settings
+.vscode
 bin/
 coverage/
 develop-eggs/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ There's a frood who really knows where his towel is.
     This version removes tile registration/removal;
     you must depend on plone.app.tiles >= 3.0.0 to avoid issues with ``collective.nitf`` tile.
 
+- Fix error when creating Plone Site, when collective.nitf is available (fix `#233`_).
+  [idgserpro]
+
 - Remove dependency on Cycle2;
   If you don't have other package depending on collective.js.cycle2 you are safe to uninstall it (closes `#200`_).
   [rodfersou]
@@ -253,3 +256,4 @@ There's a frood who really knows where his towel is.
 .. _`#200`: https://github.com/collective/collective.nitf/issues/200
 .. _`#205`: https://github.com/collective/collective.nitf/issues/205
 .. _`#208`: https://github.com/collective/collective.nitf/issues/208
+.. _`#233`: https://github.com/collective/collective.nitf/issues/233

--- a/src/collective/nitf/profiles.zcml
+++ b/src/collective/nitf/profiles.zcml
@@ -27,7 +27,7 @@
       provides="Products.CMFPlone.interfaces.INonInstallable"
       />
 
-  <!-- BBB: Plone 4.3 -->
+  <!-- BBB: Plone < 5.2 -->
   <utility
       factory=".setuphandlers.NonInstallable"
       name="collective.nitf"

--- a/src/collective/nitf/setuphandlers.py
+++ b/src/collective/nitf/setuphandlers.py
@@ -6,7 +6,7 @@ from Products.CMFQuickInstallerTool import interfaces as BBB
 from zope.interface import implementer
 
 
-@implementer(BBB.INonInstallable)  # BBB: Plone 4.3
+@implementer(BBB.INonInstallable)  # BBB: Plone < 5.2
 @implementer(INonInstallable)
 class NonInstallable(object):  # pragma: no cover
 

--- a/src/collective/nitf/setuphandlers.py
+++ b/src/collective/nitf/setuphandlers.py
@@ -18,7 +18,7 @@ class NonInstallable(object):  # pragma: no cover
         ]
 
     @staticmethod
-    def getNonInstallableProfiles(self):
+    def getNonInstallableProfiles():
         """Hide at site creation."""
         return [
             u'collective.nitf:uninstall',

--- a/src/collective/nitf/tests/test_setup.py
+++ b/src/collective/nitf/tests/test_setup.py
@@ -5,6 +5,7 @@ from collective.nitf.testing import IS_BBB
 from collective.nitf.testing import IS_PLONE_5
 from collective.nitf.testing import QIBBB
 from plone.browserlayer.utils import registered_layers
+from Products.CMFPlone.browser.admin import AddPloneSite
 
 import unittest
 
@@ -64,6 +65,19 @@ class InstallTestCase(unittest.TestCase, QIBBB):
         chain = workflow_tool.getChainForPortalType('Link')
         self.assertEqual(len(chain), 1)
         self.assertEqual(chain[0], 'one_state_workflow')
+
+    def test_hide_extensions_profiles(self):
+        app = self.layer['app']
+        request = self.layer['request']
+        add_plone_site = AddPloneSite(app, request)
+        profiles = add_plone_site.profiles()
+        extensions_profiles = profiles['extensions']
+        profiles_ids = [profile['id'] for profile in extensions_profiles]
+        nitf_profiles = [
+            profile_id for profile_id in profiles_ids
+            if profile_id.startswith(PROJECTNAME)
+        ]
+        self.assertEqual([u'collective.nitf:default'], nitf_profiles)
 
     @unittest.skipIf(IS_PLONE_5, 'No easy way to test this under Plone 5')
     def test_jsregistry(self):


### PR DESCRIPTION
New versions of Plone don't accept the `self` parameter in the `getNonInstallableProfiles` method, if we use the staticmethod decorator.

Fix #233