### PR TITLE
Update versions of setuptools/buildout

### DIFF
--- a/versions-4.3.x.cfg
+++ b/versions-4.3.x.cfg
@@ -1,6 +1,6 @@
 [versions]
-setuptools = 40.8.0
-zc.buildout = 2.13.1
+setuptools = 42.0.2
+zc.buildout = 2.13.3
 
 collective.js.bootstrap = 2.3.1.1
 plone.tiles = 2.2.2


### PR DESCRIPTION
These are the versions used by the new release of Plone 5.1