### PR TITLE
Fix robot tests 

### DIFF
--- a/src/collective/nitf/tests/keywords.robot
+++ b/src/collective/nitf/tests/keywords.robot
@@ -52,7 +52,7 @@ Create News Article
     Page Should Contain  Add Image
     Choose File  xpath=${image_field_selector}  /tmp/640px-Mandel_zoom_00_mandelbrot_set.jpg
     Click Button  Save
-    Page Should Contain  Changes saved
+    Page Should Contain  Item created
 
     # A news article can contain files
     Click Link  link=Miracle Cure
@@ -61,17 +61,18 @@ Create News Article
     Page Should Contain  Add File
     Choose File  xpath=${file_field_selector}  /tmp/random.txt
     Click Button  Save
-    Page Should Contain  Changes saved
+    Page Should Contain  Item created
 
     # A news article can contain links
     Click Link  link=Miracle Cure
     Open Add New Menu
     Click Link  css=a#link
-    Input Text  css=#title  An URL
-    Input Text  css=#description  The description of the URL
-    Input Text  css=#remoteUrl  http://foo.bar
+    Input Text  css=${title_selector}  An URL
+    Input Text  css=${description_selector}  The description of the URL
+    Click Link  External
+    Input Text  form.widgets.remoteUrl.external  http://foo.bar
     Click Button  Save
-    Page Should Contain  Changes saved
+    Page Should Contain  Item created
 
     Click Link  link=Miracle Cure
 
@@ -83,8 +84,10 @@ Update
 Delete
     Open Action Menu
     Click Link  css=a#plone-contentmenu-actions-delete
-    Click Button  Delete
-    Page Should Contain  Plone site
+    Wait Until Element Is Visible  css=.pattern-modal-buttons
+    Click Button  css=.pattern-modal-buttons #form-buttons-Delete
+    Wait Until Element Is Not Visible  css=.pattern-modal-buttons
+    Page Should Contain  Miracle Cure has been deleted
 
 Change View
     [arguments]  ${view}

--- a/src/collective/nitf/tests/test_content.robot
+++ b/src/collective/nitf/tests/test_content.robot
@@ -8,7 +8,6 @@ Suite Teardown  Close all browsers
 *** Test cases ***
 
 Test CRUD
-    [Tags]  issue_172
     Enable Autologin as  Site Administrator
     Goto Homepage
 
@@ -37,10 +36,8 @@ Test Folder Full View
     Page Should Contain  Item created
 
     Click Link  link=Test Folder
-    Sleep  1s
-    Open Display Menu
-    Click Link  link=All content
-    Check Status Message  View changed
+    Change View  All content
+    Page Should Contain Element  css=.template-full_view
 
     # all elements must be visible on the view
     Page Should Contain  ${title}

--- a/src/collective/nitf/tests/test_locking_behavior.robot
+++ b/src/collective/nitf/tests/test_locking_behavior.robot
@@ -21,7 +21,7 @@ ${body_html} =  <p>I'm free<br />I'm free<br />And freedom tastes of reality</p>
 *** Test Cases ***
 
 Test Locking Behavior
-    Enable Autologin as  Owner
+    Log In As Site Owner
     Goto Homepage
 
     Click Add News Article
@@ -45,24 +45,23 @@ Test Locking Behavior
     Click Link  link=Edit
     Page Should Contain  Locked  ${LOCKED_MESSAGE}
 
-    # FIXME: http://stackoverflow.com/q/27430323/644075
-    # Switch Browser  1
-    # Click Link  link=View
-    # Page Should Not Contain  Locked  ${LOCKED_MESSAGE}
+    Switch Browser  1
+    Click button  Save
+    Page Should Not Contain  Locked  ${LOCKED_MESSAGE}
 
-    # Switch Browser  2
-    # Go To  ${PLONE_URL}/miracle-cure
-    # Page Should Not Contain  Locked  ${LOCKED_MESSAGE}
-    # Click Link  link=Edit
+    Switch Browser  2
+    Go To  ${PLONE_URL}/miracle-cure
+    Page Should Not Contain  Locked  ${LOCKED_MESSAGE}
+    Click Link  link=Edit
 
-    # Switch Browser  1
-    # Go To  ${PLONE_URL}/miracle-cure
-    # Click Link  link=Edit
-    # Page Should Contain  Locked  ${LOCKED_MESSAGE}
+    Switch Browser  1
+    Go To  ${PLONE_URL}/miracle-cure
+    Click Link  link=Edit
+    Page Should Contain  Locked  ${LOCKED_MESSAGE}
 
-    # Switch Browser  2
-    # Go To  ${PLONE_URL}/miracle-cure
-    # Page Should Not Contain  Locked  ${LOCKED_MESSAGE}
+    Switch Browser  2
+    Go To  ${PLONE_URL}/miracle-cure
+    Page Should Not Contain  Locked  ${LOCKED_MESSAGE}
 
 *** Keywords ***
 

--- a/src/collective/nitf/tests/test_robot.py
+++ b/src/collective/nitf/tests/test_robot.py
@@ -10,20 +10,13 @@ import unittest
 files = os.listdir(os.path.dirname(__file__))
 tests = [f for f in files if f.startswith("test_") and f.endswith(".robot")]
 
-noncritical = ["Expected Failure"]
-# FIXME: https://github.com/collective/collective.nitf/issues/172
-noncritical.append("issue_172")
-
-# FIXME: Make RobotFramework tests work in Plone 5
-tests = ["test_views.robot"]
-
 
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTests(
         [
             layered(
-                robotsuite.RobotTestSuite(t, noncritical=noncritical),
+                robotsuite.RobotTestSuite(t),
                 layer=ROBOT_TESTING,
             )
             for t in tests


### PR DESCRIPTION
- Fix test_locking_behavior.robot

To open two windows, each with a different user, it was necessary to use the keyword `Log In As Site Owner` instead of `Enable Autologin as Owner`.

Fix: https://stackoverflow.com/questions/27430323/how-to-run-a-robot-framework-test-with-2-different-users-in-2-different-browser

- Fix test_content.robot

Fixes #172 